### PR TITLE
Removed margin-right from docs-next

### DIFF
--- a/website/static/css/docs-prevnext.css
+++ b/website/static/css/docs-prevnext.css
@@ -53,7 +53,6 @@
 
 .button.docs-next {
   margin-left: auto;
-  margin-right: -1.6rem;
 }
 
 .docs-next span:first-child {


### PR DESCRIPTION
Removed margin-right from docs-next because it goes out of the screen while working on mobile and it's now as far as the Getting Started button from it's left.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
